### PR TITLE
🔖 release prep v4.0.0 (audit fixes + version)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Formato basado en [Keep a Changelog](https://keepachangelog.com/). El proyecto sigue SemVer.
 
-## [Unreleased]
+## [4.0.0] — 2026-06-09
 
 ### Removed
 

--- a/docs/10-performance.md
+++ b/docs/10-performance.md
@@ -47,7 +47,7 @@
 
 - Cero frameworks de UI runtime.
 - 3 scripts deferred (ver [09-components](./09-components.md)).
-- Sin polyfills (Cloudflare workers / modern browsers only).
+- Sin polyfills (modern browsers only).
 
 ### CSS
 

--- a/e2e/a11y.spec.ts
+++ b/e2e/a11y.spec.ts
@@ -15,7 +15,7 @@ async function seriousViolations(page: Page) {
 for (const path of ['/', '/en/']) {
   for (const scheme of ['light', 'dark'] as const) {
     test(`a11y ${scheme} · ${path}`, async ({ page }) => {
-      await page.emulateMedia({ colorScheme: scheme });
+      await page.emulateMedia({ colorScheme: scheme, reducedMotion: 'reduce' });
       await page.goto(path);
       expect(await seriousViolations(page)).toEqual([]);
     });

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "portfolio",
   "description": "Portfolio de Sebastián González Ríos",
   "type": "module",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "private": true,
   "author": {
     "name": "Sebastián González Ríos",
@@ -33,7 +33,6 @@
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@resvg/resvg-wasm": "^2.6.2",
     "@supabase/supabase-js": "^2.107.0",
-    "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.3.0",
     "astro": "^6.4.4",
     "satori": "^0.26.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.107.0
         version: 2.107.0
-      '@tailwindcss/typography':
-        specifier: ^0.5.19
-        version: 0.5.19(tailwindcss@4.3.0)
       '@tailwindcss/vite':
         specifier: ^4.3.0
         version: 4.3.0(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
@@ -921,11 +918,6 @@ packages:
     resolution: {integrity: sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==}
     engines: {node: '>= 20'}
 
-  '@tailwindcss/typography@0.5.19':
-    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
-    peerDependencies:
-      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
-
   '@tailwindcss/vite@4.3.0':
     resolution: {integrity: sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==}
     peerDependencies:
@@ -1385,11 +1377,6 @@ packages:
   css-what@6.2.2:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
-
-  cssesc@3.0.0:
-    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
-    engines: {node: '>=4'}
-    hasBin: true
 
   csso@5.0.5:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
@@ -2471,10 +2458,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  postcss-selector-parser@6.0.10:
-    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
-    engines: {node: '>=4'}
-
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
@@ -3032,9 +3015,6 @@ packages:
         optional: true
       uploadthing:
         optional: true
-
-  util-deprecate@1.0.2:
-    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
@@ -4114,11 +4094,6 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
 
-  '@tailwindcss/typography@0.5.19(tailwindcss@4.3.0)':
-    dependencies:
-      postcss-selector-parser: 6.0.10
-      tailwindcss: 4.3.0
-
   '@tailwindcss/vite@4.3.0(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.0
@@ -4681,8 +4656,6 @@ snapshots:
       source-map-js: 1.2.1
 
   css-what@6.2.2: {}
-
-  cssesc@3.0.0: {}
 
   csso@5.0.5:
     dependencies:
@@ -5980,11 +5953,6 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  postcss-selector-parser@6.0.10:
-    dependencies:
-      cssesc: 3.0.0
-      util-deprecate: 1.0.2
-
   postcss-value-parser@4.2.0: {}
 
   postcss@8.5.15:
@@ -6657,8 +6625,6 @@ snapshots:
       node-fetch-native: 1.6.7
       ofetch: 1.5.1
       ufo: 1.6.4
-
-  util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,7 +1,6 @@
 @import "tailwindcss";
 @import "./fonts.css";
 
-@plugin "@tailwindcss/typography";
 
 @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
 


### PR DESCRIPTION
## Resumen

Preparación del release a producción tras la **auditoría pre-prod**. Arregla el único punto rojo (e2e a11y flaky), una limpieza de dependencia sin uso, un retoque de doc y el versionado a **4.0.0**.

## Cambios

- **✅ Estabiliza el e2e a11y**: `e2e/a11y.spec.ts` emula `prefers-reduced-motion: reduce` → el contenido queda en estado final estable cuando corre axe (antes, la animación *reveal* a mitad de fade hacía medir mal el contraste y fallaba ~2/4 de forma intermitente en la suite paralela). Verificado: full e2e **10/10 ×3 seguidas**.
- **🔥 Elimina `@tailwindcss/typography`**: dependencia sin uso (no hay ninguna clase `prose`; `max-w-prose` es core de Tailwind y sigue funcionando). Fuera el `@plugin` de `globals.css` y el dep.
- **📚 Doc**: `10-performance.md` quita una mención obsoleta a "Cloudflare workers" (ya no hay worker).
- **🔖 v4.0.0**: bump en `package.json` y `CHANGELOG` (`[Unreleased]` → `[4.0.0] — 2026-06-09`). Major coherente con el patrón del repo (backoffice fuera del repo + Astro 5→6 + arquitectura estática).

## Auditoría — resto del estado (todo OK)

- `check` 0 errores · `test` 29/29 · `build` estático (`dist/` sin worker) · `e2e` 10/10 estable.
- Sin referencias a admin/SSR/`@supabase/ssr`/`@astrojs/cloudflare`; sin `console.log`/`any`/`TODO`.
- CSP por meta con hashes (sin `unsafe-inline`) + `_headers` con HSTS/COOP/CORP. Docs/config consistentes.
- Nota menor no bloqueante: `IconDef.color` en el registro de iconos ya no se lee (los colores viven en `globals.css`); se deja como referencia documental.

## Tras mergear

Queda el PR de release **`develop → main`** + tag **`v4.0.0`** para publicar en `sebasgrios.es`.