### PR TITLE
⚡️ v4.0.2: mobile perf (drop unused Supabase preconnect, cache /_astro)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Formato basado en [Keep a Changelog](https://keepachangelog.com/). El proyecto sigue SemVer.
 
+## [4.0.2] — 2026-06-09
+
+### Changed
+
+- **Perf (móvil)**: eliminado el `preconnect`/`dns-prefetch` a Supabase (Lighthouse lo marcaba como conexión sin usar: las imágenes se optimizan a `/_astro` en build, no hay peticiones a Supabase en runtime) y añadido `Cache-Control: immutable` para `/_astro/*` en `_headers`.
+
 ## [4.0.1] — 2026-06-09
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "portfolio",
   "description": "Portfolio de Sebastián González Ríos",
   "type": "module",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "private": true,
   "author": {
     "name": "Sebastián González Ríos",

--- a/public/_headers
+++ b/public/_headers
@@ -8,6 +8,9 @@
   Cross-Origin-Resource-Policy: same-origin
   Content-Security-Policy: frame-ancestors 'self'; upgrade-insecure-requests
 
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+
 /fonts/*
   Cache-Control: public, max-age=31536000, immutable
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -3,7 +3,6 @@ import BgField from '@/components/BgField.astro';
 import BgNoise from '@/components/BgNoise.astro';
 import type { Locale } from '@/config/i18n';
 import { SITE } from '@/config/site';
-import { SUPABASE } from '@/config/supabase';
 import '@/styles/globals.css';
 
 interface Props {
@@ -140,8 +139,6 @@ const jsonLd = graph.length
     <meta name="twitter:image" content={ogImageUrl} />
     <meta name="twitter:image:alt" content={ogImageAltText} />
     {jsonLd && <script is:inline type="application/ld+json" set:html={jsonLd} />}
-    <link rel="preconnect" href={SUPABASE.url} crossorigin />
-    <link rel="dns-prefetch" href={SUPABASE.url} />
     <script is:inline>
       (function () {
         try {


### PR DESCRIPTION
## Resumen

Pequeñas mejoras de rendimiento móvil tras el LCP fix de v4.0.1 (móvil ya en 96; LCP 5,9s → 2,5s). Wins claros sin downside.

## Cambios

- **Quita el `preconnect`/`dns-prefetch` a Supabase** (`BaseLayout`): Lighthouse lo marcaba como **conexión preestablecida sin usar** — las imágenes se optimizan a `/_astro` en build, no hay peticiones a Supabase en runtime. (También se elimina el import de `SUPABASE`, que solo se usaba ahí.)
- **`Cache-Control: immutable` para `/_astro/*`** en `_headers` (assets con hash → cacheables para siempre; cubre el aviso "tiempos de vida de caché").
- **v4.0.2** + CHANGELOG.

## Recomendación aparte (dashboard, mayor impacto)

El mayor lastre de render-blocking en móvil (~480 ms) es **`cloudflare-static/email-decode.min.js`**, que inyecta Cloudflare por la **Ofuscación de Email** (Scrape Shield) al detectar el `mailto:`. Para quitarlo: Cloudflare → dominio → **Scrape Shield → Email Address Obfuscation: OFF**. No es código (no entra en este PR).

## Verificación

- `check` 0 · `test` 29/29 · `build` OK · `e2e` 10/10.
- En `dist`: HTML sin `preconnect`/`dns-prefetch`; `/_astro/* immutable` en `_headers`.
- Re-verificar en prod: LH móvil debería subir algo (96 → ~98+ con el toggle de Email Obfuscation).