### PR TITLE
⚡️ v4.0.3: inline critical CSS (remove last render-blocking request)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Formato basado en [Keep a Changelog](https://keepachangelog.com/). El proyecto sigue SemVer.
 
+## [4.0.3] — 2026-06-09
+
+### Changed
+
+- **Perf**: CSS crítico **inlineado** en el `<head>` (`build.inlineStylesheets: 'always'`) → elimina la última petición render-blocking y adelanta el descubrimiento de las fuentes. La CSP estricta lo hashea automáticamente (verificado en preview: sin violaciones, sin `'unsafe-inline'`).
+
 ## [4.0.2] — 2026-06-09
 
 ### Changed

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,9 @@ import { defineConfig } from 'astro/config';
 export default defineConfig({
   site: 'https://sebasgrios.es',
   output: 'static',
+  build: {
+    inlineStylesheets: 'always',
+  },
   security: {
     csp: {
       directives: [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "portfolio",
   "description": "Portfolio de Sebastián González Ríos",
   "type": "module",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "private": true,
   "author": {
     "name": "Sebastián González Ríos",


### PR DESCRIPTION
## Resumen

Última optimización de perf móvil: inlinea el CSS crítico para eliminar la única petición render-blocking que quedaba (tras quitar `email-decode.min.js` vía el toggle de Scrape Shield).

## Cambio

- `astro.config.mjs`: `build.inlineStylesheets: 'always'` → el CSS (~14 KB) se inyecta en el `<head>` en vez de cargarse como `/_astro/*.css` externo. Quita el render-blocking y adelanta el descubrimiento de los `@font-face`.

## CSP (verificado)

Astro **hashea automáticamente** el `<style>` inline e incluye el hash en `style-src` del `<meta>` CSP (3 hashes ahora). Verificado en `astro preview`: el `<style>` parsea (112 reglas, no bloqueado), `bodyBg`/fuentes aplican, **consola sin violaciones CSP**, página estilada correctamente. Se mantiene **sin `'unsafe-inline'`**.

## Trade-off

+14 KB en el HTML de cada página (el CSS ya no se cachea por separado). Asumible en un sitio de 3 páginas; a cambio, FCP/LCP móvil mejoran (Lighthouse estimaba ~860 ms de render-blocking eliminado).

## Verificación

- `check` 0 · `test` 29/29 · `build` OK (sin `<link stylesheet>` externo, 1 `<style>` inline) · `e2e` 10/10.
- Re-verificar LH móvil en prod tras desplegar (esperado ~98-99).