### PR TITLE
💄 v4.1.0: redesign hero stats + fix contact/footer spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Formato basado en [Keep a Changelog](https://keepachangelog.com/). El proyecto s
 
 ### Changed
 
-- **Héroe · stats**: rediseño de los bloques de cifras. "Años de experiencia" pasa a la **parte superior** y "sectores"/"proyectos" a **dos columnas debajo**; bloques **rectangulares de ancho contenido** (no a todo lo ancho), con la cifra grande y la etiqueta debajo. La etiqueta de sectores deja de duplicar el número.
+- **Héroe · stats**: rediseño de los bloques de cifras. "Años de experiencia" pasa a la **parte superior** y "sectores"/"proyectos" a **dos columnas debajo**; bloques **rectangulares** con la cifra grande y la etiqueta debajo. En escritorio el bloque de años es de **ancho contenido** (asimétrico, no ocupa el ancho de los dos de abajo) y en móvil se vuelve **simétrico** (a todo el ancho). La etiqueta de sectores deja de duplicar el número y "proyectos propios en producción" se acorta a "proyectos propios".
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Formato basado en [Keep a Changelog](https://keepachangelog.com/). El proyecto s
 
 ### Changed
 
-- **Héroe · stats**: rediseño de los bloques de cifras. "Años de experiencia" pasa a un **banner rectangular a lo ancho** en la parte superior, con "sectores" y "proyectos" en dos columnas debajo (todos horizontales/rectangulares, con jerarquía). La etiqueta de sectores deja de duplicar el número.
+- **Héroe · stats**: rediseño de los bloques de cifras. "Años de experiencia" pasa a la **parte superior** y "sectores"/"proyectos" a **dos columnas debajo**; bloques **rectangulares de ancho contenido** (no a todo lo ancho), con la cifra grande y la etiqueta debajo. La etiqueta de sectores deja de duplicar el número.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Formato basado en [Keep a Changelog](https://keepachangelog.com/). El proyecto sigue SemVer.
 
+## [4.1.0] — 2026-06-09
+
+### Changed
+
+- **Héroe · stats**: rediseño de los bloques de cifras. "Años de experiencia" pasa a un **banner rectangular a lo ancho** en la parte superior, con "sectores" y "proyectos" en dos columnas debajo (todos horizontales/rectangulares, con jerarquía). La etiqueta de sectores deja de duplicar el número.
+
+### Fixed
+
+- **Contacto · footer**: faltaba separación entre la sección de Contacto y el divisor del footer (el footer quedó fuera de `<main>` tras el fix de landmarks de a11y, perdiendo el `gap` de sección). Se añade `margin-top` al footer con el ritmo de sección.
+
 ## [4.0.3] — 2026-06-09
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "portfolio",
   "description": "Portfolio de Sebastián González Ríos",
   "type": "module",
-  "version": "4.0.3",
+  "version": "4.1.0",
   "private": true,
   "author": {
     "name": "Sebastián González Ríos",

--- a/src/config/copy.ts
+++ b/src/config/copy.ts
@@ -53,7 +53,7 @@ export const COPY: Record<Locale, ChromeCopy> = {
       cta: 'Hablemos',
       statYears: 'de experiencia profesional',
       statSectors: 'sectores',
-      statProjects: 'proyectos propios en producción',
+      statProjects: 'proyectos propios',
     },
     sections: {
       experience: {
@@ -104,7 +104,7 @@ export const COPY: Record<Locale, ChromeCopy> = {
       cta: "Let's talk",
       statYears: 'of professional experience',
       statSectors: 'sectors',
-      statProjects: 'live personal projects',
+      statProjects: 'personal projects',
     },
     sections: {
       experience: {

--- a/src/sections/Footer.astro
+++ b/src/sections/Footer.astro
@@ -13,7 +13,7 @@ const { profile } = Astro.props;
 const year = new Date().getFullYear();
 ---
 
-<footer class="wrap pt-10 pb-[60px] border-t border-hairline">
+<footer class="wrap mt-[clamp(48px,7vw,96px)] pt-10 pb-[60px] border-t border-hairline">
   <div class="flex flex-wrap items-center justify-between gap-4">
     <div class="text-text-faint text-[0.85rem]">© {year} {profile.fullName}</div>
     <div class="flex gap-2">

--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -135,7 +135,7 @@ const sectorsLabel = copy.hero.statSectors;
       <div
         class="enter [animation-delay:0.24s] mt-10 flex flex-col gap-3.5 w-full max-w-[360px] max-[940px]:mx-auto"
       >
-        <Glass class="stat self-start px-6 py-4 rounded-[var(--radius-glass-sm)]">
+        <Glass class="stat self-start max-[940px]:self-stretch px-6 py-4 rounded-[var(--radius-glass-sm)]">
           <div
             class="font-display font-black text-[clamp(1.9rem,4vw,2.6rem)] leading-none tracking-[-0.03em] bg-[linear-gradient(120deg,var(--accent-bright),oklch(0.7_0.18_calc(var(--accent-h)+55)))] bg-clip-text text-transparent"
           >

--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -133,32 +133,32 @@ const sectorsLabel = copy.hero.statSectors;
         }
       </div>
       <div
-        class="enter [animation-delay:0.24s] mt-10 flex flex-col gap-3.5 max-[940px]:max-w-[460px] max-[940px]:mx-auto"
+        class="enter [animation-delay:0.24s] mt-10 flex flex-col gap-3.5 w-full max-w-[360px] max-[940px]:mx-auto"
       >
-        <Glass class="stat flex items-center gap-4 px-6 py-[18px] rounded-[var(--radius-glass-sm)]">
+        <Glass class="stat self-start px-6 py-4 rounded-[var(--radius-glass-sm)]">
           <div
-            class="font-display font-black text-[clamp(2rem,4.2vw,2.7rem)] leading-none tracking-[-0.03em] bg-[linear-gradient(120deg,var(--accent-bright),oklch(0.7_0.18_calc(var(--accent-h)+55)))] bg-clip-text text-transparent whitespace-nowrap"
+            class="font-display font-black text-[clamp(1.9rem,4vw,2.6rem)] leading-none tracking-[-0.03em] bg-[linear-gradient(120deg,var(--accent-bright),oklch(0.7_0.18_calc(var(--accent-h)+55)))] bg-clip-text text-transparent"
           >
             +{stats.yearsOfExperience} {locale === 'es' ? 'años' : 'years'}
           </div>
-          <div class="text-[0.85rem] text-text-soft leading-snug">{copy.hero.statYears}</div>
+          <div class="text-[0.8rem] text-text-soft mt-1.5">{copy.hero.statYears}</div>
         </Glass>
-        <div class="flex gap-3.5 max-[460px]:gap-2.5">
-          <Glass class="stat flex-1 flex items-center gap-3 px-5 py-[18px] rounded-[var(--radius-glass-sm)]">
+        <div class="flex gap-3.5">
+          <Glass class="stat flex-1 px-5 py-4 rounded-[var(--radius-glass-sm)]">
             <div
-              class="font-display font-black text-[clamp(1.7rem,3.6vw,2.3rem)] leading-none tracking-[-0.03em] bg-[linear-gradient(120deg,var(--accent-bright),oklch(0.7_0.18_calc(var(--accent-h)+55)))] bg-clip-text text-transparent"
+              class="font-display font-black text-[clamp(1.6rem,3.4vw,2.1rem)] leading-none tracking-[-0.03em] bg-[linear-gradient(120deg,var(--accent-bright),oklch(0.7_0.18_calc(var(--accent-h)+55)))] bg-clip-text text-transparent"
             >
               {stats.sectorsCount}
             </div>
-            <div class="text-[0.78rem] text-text-soft leading-tight">{sectorsLabel}</div>
+            <div class="text-[0.8rem] text-text-soft mt-1.5">{sectorsLabel}</div>
           </Glass>
-          <Glass class="stat flex-1 flex items-center gap-3 px-5 py-[18px] rounded-[var(--radius-glass-sm)]">
+          <Glass class="stat flex-1 px-5 py-4 rounded-[var(--radius-glass-sm)]">
             <div
-              class="font-display font-black text-[clamp(1.7rem,3.6vw,2.3rem)] leading-none tracking-[-0.03em] bg-[linear-gradient(120deg,var(--accent-bright),oklch(0.7_0.18_calc(var(--accent-h)+55)))] bg-clip-text text-transparent"
+              class="font-display font-black text-[clamp(1.6rem,3.4vw,2.1rem)] leading-none tracking-[-0.03em] bg-[linear-gradient(120deg,var(--accent-bright),oklch(0.7_0.18_calc(var(--accent-h)+55)))] bg-clip-text text-transparent"
             >
               {stats.projectsCount}
             </div>
-            <div class="text-[0.78rem] text-text-soft leading-tight">{copy.hero.statProjects}</div>
+            <div class="text-[0.8rem] text-text-soft mt-1.5">{copy.hero.statProjects}</div>
           </Glass>
         </div>
       </div>

--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -29,7 +29,7 @@ const floatBadges = pickLocaleArray(profile.heroBadges, locale);
 const nameParts = profile.fullName.split(' ');
 const firstName = nameParts[0] ?? profile.fullName;
 const lastName = nameParts.slice(1).join(' ');
-const sectorsLabel = `${stats.sectorsCount} ${copy.hero.statSectors}`;
+const sectorsLabel = copy.hero.statSectors;
 ---
 
 <header
@@ -133,32 +133,34 @@ const sectorsLabel = `${stats.sectorsCount} ${copy.hero.statSectors}`;
         }
       </div>
       <div
-        class="enter [animation-delay:0.24s] flex flex-wrap gap-3.5 mt-10 max-[720px]:[&>.stat]:flex-1 max-[720px]:[&>.stat]:basis-[140px] max-[720px]:[&>.stat]:min-w-0 max-[460px]:gap-2.5"
+        class="enter [animation-delay:0.24s] mt-10 flex flex-col gap-3.5 max-[940px]:max-w-[460px] max-[940px]:mx-auto"
       >
-        <Glass class="stat px-5 py-4 rounded-[var(--radius-glass-sm)] min-w-[120px] flex-1 basis-[140px]">
+        <Glass class="stat flex items-center gap-4 px-6 py-[18px] rounded-[var(--radius-glass-sm)]">
           <div
-            class="font-display font-black text-[clamp(1.8rem,4vw,2.6rem)] leading-none tracking-[-0.03em] bg-[linear-gradient(120deg,var(--accent-bright),oklch(0.7_0.18_calc(var(--accent-h)+55)))] bg-clip-text text-transparent"
+            class="font-display font-black text-[clamp(2rem,4.2vw,2.7rem)] leading-none tracking-[-0.03em] bg-[linear-gradient(120deg,var(--accent-bright),oklch(0.7_0.18_calc(var(--accent-h)+55)))] bg-clip-text text-transparent whitespace-nowrap"
           >
             +{stats.yearsOfExperience} {locale === 'es' ? 'años' : 'years'}
           </div>
-          <div class="text-[0.8rem] text-text-soft mt-1.5">{copy.hero.statYears}</div>
+          <div class="text-[0.85rem] text-text-soft leading-snug">{copy.hero.statYears}</div>
         </Glass>
-        <Glass class="stat px-5 py-4 rounded-[var(--radius-glass-sm)] min-w-[120px] flex-1 basis-[140px]">
-          <div
-            class="font-display font-black text-[clamp(1.8rem,4vw,2.6rem)] leading-none tracking-[-0.03em] bg-[linear-gradient(120deg,var(--accent-bright),oklch(0.7_0.18_calc(var(--accent-h)+55)))] bg-clip-text text-transparent"
-          >
-            {stats.sectorsCount}
-          </div>
-          <div class="text-[0.8rem] text-text-soft mt-1.5">{sectorsLabel}</div>
-        </Glass>
-        <Glass class="stat px-5 py-4 rounded-[var(--radius-glass-sm)] min-w-[120px] flex-1 basis-[140px]">
-          <div
-            class="font-display font-black text-[clamp(1.8rem,4vw,2.6rem)] leading-none tracking-[-0.03em] bg-[linear-gradient(120deg,var(--accent-bright),oklch(0.7_0.18_calc(var(--accent-h)+55)))] bg-clip-text text-transparent"
-          >
-            {stats.projectsCount}
-          </div>
-          <div class="text-[0.8rem] text-text-soft mt-1.5">{copy.hero.statProjects}</div>
-        </Glass>
+        <div class="flex gap-3.5 max-[460px]:gap-2.5">
+          <Glass class="stat flex-1 flex items-center gap-3 px-5 py-[18px] rounded-[var(--radius-glass-sm)]">
+            <div
+              class="font-display font-black text-[clamp(1.7rem,3.6vw,2.3rem)] leading-none tracking-[-0.03em] bg-[linear-gradient(120deg,var(--accent-bright),oklch(0.7_0.18_calc(var(--accent-h)+55)))] bg-clip-text text-transparent"
+            >
+              {stats.sectorsCount}
+            </div>
+            <div class="text-[0.78rem] text-text-soft leading-tight">{sectorsLabel}</div>
+          </Glass>
+          <Glass class="stat flex-1 flex items-center gap-3 px-5 py-[18px] rounded-[var(--radius-glass-sm)]">
+            <div
+              class="font-display font-black text-[clamp(1.7rem,3.6vw,2.3rem)] leading-none tracking-[-0.03em] bg-[linear-gradient(120deg,var(--accent-bright),oklch(0.7_0.18_calc(var(--accent-h)+55)))] bg-clip-text text-transparent"
+            >
+              {stats.projectsCount}
+            </div>
+            <div class="text-[0.78rem] text-text-soft leading-tight">{copy.hero.statProjects}</div>
+          </Glass>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Resumen

Bug de espaciado en producción + rediseño de los stats del héroe (+ pasada de alineación).

## Cambios

- **🐛 Hueco Contacto ↔ footer**: el footer quedó **fuera de `<main>`** tras el fix de landmarks de a11y, perdiendo el `gap` de sección (que vive en `main`). Se añade `margin-top: clamp(48px,7vw,96px)` al footer → recupera el ritmo (90px sobre el divisor).
- **💄 Rediseño de stats del héroe**: "años de experiencia" como **bloque compacto arriba** (ancho según su contenido, **asimétrico** respecto a la fila inferior — no abarca el ancho de los dos de abajo); "sectores" y "proyectos" en **dos columnas debajo**. Cifra grande con la **etiqueta debajo** (underscore), bloques **rectangulares de ancho contenido** (no a todo lo ancho). Corregido el número duplicado en sectores.
- **Pasada de alineación**: H2 de todas las secciones de contenido al mismo borde (112px del `.wrap`); Contacto centrado a propósito; ritmo vertical consistente.

## Verificación
- Desktop (1280) y móvil (375): asimetría correcta (experiencia 201px vs fila 360/335px), responsive, consola sin errores.
- `check` 0 · `test` 29/29 · `build` OK · `e2e` 10/10.