### PR TITLE
⚡️ Eliminar el CLS por font-swap con fallbacks de métricas ajustadas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Formato basado en [Keep a Changelog](https://keepachangelog.com/). El proyecto sigue SemVer.
 
+## [4.1.1] — 2026-06-10
+
+### Fixed
+
+- **Rendimiento (móvil) · CLS**: el *swap* de fuente (FOUT) reflowaba la columna del héroe al cargar Satoshi/General Sans bajo *throttling*, disparando el **CLS a 0,314** (Lighthouse móvil **81**). Se añaden **fuentes de respaldo con métricas ajustadas** (`size-adjust`/`ascent-override`/`descent-override`/`line-gap-override`, generadas con `@capsizecss/core` a partir de las métricas reales de los `.woff2` y matcheadas contra Arial), conectadas a `--font-display`/`--font-sans`. El respaldo ocupa exactamente la misma caja que la fuente web, así que el *swap* **no produce desplazamiento** (CLS≈0 verificado a 360/375/412/1280 px) y se mantiene la fuente *custom* siempre visible (sin el sacrificio de `font-display: optional`).
+
 ## [4.1.0] — 2026-06-09
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "portfolio",
   "description": "Portfolio de Sebastián González Ríos",
   "type": "module",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "private": true,
   "author": {
     "name": "Sebastián González Ríos",

--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -63,3 +63,30 @@
   font-style: normal;
   font-display: swap;
 }
+
+/* Metric-adjusted fallbacks — zero-CLS font swap.
+   Generated once with @capsizecss/core `createFontStack()` from the real woff2
+   metrics (Satoshi-Black / GeneralSans-Regular: unitsPerEm 1000, ascent 1010,
+   descent -240, lineGap 100, xWidthAvg 486 / 450) matched against Arial. The
+   overrides make Arial occupy the exact same box as the web font, so when the
+   real font swaps in there is no reflow. Wired into --font-display / --font-sans
+   in globals.css. Regenerate if the font files change. */
+@font-face {
+  font-family: "Satoshi Fallback";
+  src: local("Arial"), local("ArialMT");
+  font-display: swap;
+  ascent-override: 92.6458%;
+  descent-override: 22.0149%;
+  line-gap-override: 9.1729%;
+  size-adjust: 109.0173%;
+}
+
+@font-face {
+  font-family: "General Sans Fallback";
+  src: local("Arial"), local("ArialMT");
+  font-display: swap;
+  ascent-override: 100.0575%;
+  descent-override: 23.776%;
+  line-gap-override: 9.9067%;
+  size-adjust: 100.9419%;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -19,8 +19,8 @@
   --color-glass-bg: var(--glass-bg);
   --color-glass-border: var(--glass-border);
 
-  --font-display: "Satoshi", system-ui, sans-serif;
-  --font-sans: "General Sans", system-ui, sans-serif;
+  --font-display: "Satoshi", "Satoshi Fallback", system-ui, sans-serif;
+  --font-sans: "General Sans", "General Sans Fallback", system-ui, sans-serif;
   --font-mono: "JetBrains Mono", ui-monospace, monospace;
 
   --radius-glass: 22px;


### PR DESCRIPTION
## Problema

Lighthouse **móvil cayó a 81** (todo lo demás sigue en 100). El único factor es **CLS = 0,314**, atribuido a `div.[grid-area:main]` (la columna de texto del héroe), con las 3 fuentes en la cadena crítica.

**Causa raíz:** todas las `@font-face` usan `font-display: swap` y el respaldo era `system-ui`, cuyas métricas no coinciden con Satoshi / General Sans. Bajo el *throttling* móvil las fuentes llegan tarde y, al hacer *swap*, el `h1`/rol/*lead*/stats se recolocan → reflow vertical de la columna. (En CI/localhost las fuentes cargan instantáneas, por eso el job de Lighthouse pasaba.)

## Solución

**Fuentes de respaldo con métricas ajustadas** (estilo Fontaine/capsize), generadas una sola vez con `@capsizecss/core` a partir de las métricas reales de los `.woff2` y matcheadas contra Arial:

- `Satoshi Fallback` y `General Sans Fallback` en `fonts.css` con `size-adjust` / `ascent-override` / `descent-override` / `line-gap-override`.
- Conectadas a `--font-display` / `--font-sans` en `globals.css`.

El respaldo ocupa **exactamente la misma caja** que la fuente web, así que el *swap* no produce desplazamiento. Se mantiene `font-display: swap` (texto visible al instante) y la fuente *custom* siempre se renderiza — sin el sacrificio de `font-display: optional`. **Cero dependencias permanentes** (los overrides van como CSS estático).

## Verificación

Prueba determinista en navegador (alto de la columna `[grid-area:main]` y del `<header>` en render todo-fallback vs. todo-real):

| Ancho | Δ columna | Δ header |
|-------|-----------|----------|
| 360px | **0** | **0** |
| 375px | **0** | **0** |
| **412px** (audit móvil de Lighthouse) | **0** | **0** |
| 1280px (escritorio) | **0** | **0** |
| 320px (iPhone SE 1ª gen, < ancho auditado) | −44 | −43 |

- `pnpm check` 0 errores · `pnpm test` 29/29 · `pnpm build` OK (OG generadas) · `e2e` 10/10 (incl. axe a11y).
- `@font-face` de respaldo **inlineado y cubierto por el hash de la CSP** en el HTML construido — sin `'unsafe-inline'`, sin violaciones en consola.
- Diseño Liquid Glass intacto (sin regresión visual).

El −44px residual a 320px (reajuste de línea; el `size-adjust` matchea el ancho *medio*, no cada línea) está por debajo de la anchura que audita Lighthouse y es aun así mejor que el `system-ui` sin ajustar anterior.