### PR TITLE
🔒️ Hardening: security.txt (RFC 9116) + endurecer CSP img-src

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Formato basado en [Keep a Changelog](https://keepachangelog.com/). El proyecto sigue SemVer.
 
+## [4.1.2] — 2026-06-10
+
+### Security
+
+- **`security.txt` (RFC 9116)**: añadido en `/.well-known/security.txt` con el contacto para reportar incidencias de seguridad (resuelve el aviso "Security.txt no configurado" del Security Center de Cloudflare).
+- **CSP `img-src` endurecido**: eliminado el comodín `https://*.supabase.co` (vestigial — las imágenes se optimizan a `/_astro` en *build* vía `astro:assets`, no hay peticiones a Supabase en *runtime*). Queda en `img-src 'self' data:`. `image.remotePatterns` se mantiene intacto (lo usa el *build* para descargar las imágenes de origen).
+
 ## [4.1.1] — 2026-06-10
 
 ### Fixed

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,7 +16,7 @@ export default defineConfig({
         "form-action 'self'",
         "object-src 'none'",
         "frame-src 'none'",
-        "img-src 'self' data: https://*.supabase.co",
+        "img-src 'self' data:",
         "font-src 'self' data:",
         "connect-src 'self' https://cloudflareinsights.com",
       ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "portfolio",
   "description": "Portfolio de Sebastián González Ríos",
   "type": "module",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "private": true,
   "author": {
     "name": "Sebastián González Ríos",

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,4 @@
+Contact: mailto:contact@sebasgrios.es
+Expires: 2027-06-10T00:00:00.000Z
+Preferred-Languages: es, en
+Canonical: https://sebasgrios.es/.well-known/security.txt


### PR DESCRIPTION
Cierra dos hallazgos del **Security Center de Cloudflare** (ninguno era una vulnerabilidad de la web; las cabeceras/CSP/TLS ya eran A+).

## Cambios

### `security.txt` (RFC 9116)
Nuevo `public/.well-known/security.txt` con el contacto para reportes de seguridad → servido en `https://sebasgrios.es/.well-known/security.txt`. Resuelve el aviso *"Security.txt no configurado"*.

### CSP `img-src` endurecido
`img-src 'self' data: https://*.supabase.co` → **`img-src 'self' data:`**. El comodín de Supabase era **vestigial**: las imágenes se optimizan a `/_astro` en *build* vía `astro:assets`, no hay peticiones a Supabase en *runtime* (verificado: la única aparición de "supabase" en el HTML servido era la propia directiva). `image.remotePatterns` se mantiene intacto en `astro.config.mjs` (lo usa el *build* para descargar las imágenes de origen).

## Verificación
- `check` 0 errores · `test` 29/29 · `build` OK (12 imágenes optimizadas a `/_astro`, OG generadas) · `e2e` 10/10 (incl. axe a11y).
- **Preview del build servido** (CSP aplicada por el navegador): tras recorrer toda la página, las 6 imágenes cargan desde `/_astro` (mismo origen), **0 imágenes rotas, 0 orígenes externos, 0 violaciones de CSP** en consola.
- HTML construido: `img-src 'self' data:;` · `security.txt` servido con su contenido correcto.

## Fuera de esta PR (pendiente en tu lado, es DNS/panel)
- **DMARC** (lo único con valor real del análisis): publicar TXT en `_dmarc` (`v=DMARC1; p=quarantine; rua=mailto:contact@sebasgrios.es; fo=1`, luego subir a `p=reject`). Resuelve los 3 *"Errores de registro DMARC"*.
- **Bot Fight Mode / AI Labyrinth**: sugerencias de producto de Cloudflare, opcionales/innecesarias para un sitio estático.