### PR TITLE
🔒 Endurecimiento de seguridad, CI y ajustes del repositorio

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything in the repository.
+* @sebasgrios

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,36 @@
+name: Bug report
+description: Report something that is not working as expected on the site.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected to happen.
+      placeholder: When I open the timeline on mobile, ...
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can the issue be reproduced?
+      placeholder: |
+        1. Go to '...'
+        2. Scroll to '...'
+        3. See error
+    validations:
+      required: true
+  - type: input
+    id: url
+    attributes:
+      label: Affected page
+      description: The URL where the issue occurs.
+      placeholder: https://sebasgrios.es/es/
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser, operating system and device.
+      placeholder: Chrome 140 · macOS 15 · iPhone 15

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/sebasgrios/sebasgrios/security/advisories/new
+    about: Please report security issues privately, not as a public issue.
+  - name: Contact
+    url: https://sebasgrios.es
+    about: For anything else, reach out through the website.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: Feature request
+description: Suggest an improvement or new idea for the site.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What problem does this solve, or what would it improve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the idea or behaviour you would like to see.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches you have thought about.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Resumen
+
+<!-- Describe brevemente el motivo del cambio y el problema que resuelve. -->
+
+## Cambios
+
+<!-- Enumera los cambios principales introducidos por esta PR. -->
+
+-
+
+## Notas
+
+<!-- Información adicional para la persona revisora: capturas, decisiones de diseño,
+pasos de despliegue (p. ej. purga de caché), enlaces relacionados, etc. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+
+# Cancel superseded runs on the same ref to save minutes.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm check
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm test
+
+  e2e:
+    name: e2e
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright install --with-deps chromium
+      - run: pnpm e2e
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+If you discover a security vulnerability in this project, please report it
+privately. **Do not open a public issue.**
+
+Use GitHub's private vulnerability reporting:
+[Report a vulnerability](https://github.com/sebasgrios/sebasgrios/security/advisories/new).
+
+Please include:
+
+- A description of the vulnerability and its potential impact.
+- Steps to reproduce or a proof of concept.
+- Any relevant URLs, requests or configuration.
+
+You will receive an acknowledgement as soon as possible, and updates as the
+issue is investigated and resolved.
+
+## Scope
+
+This repository hosts a static personal portfolio served on Cloudflare Pages.
+Reports about the site (`sebasgrios.es`), its build pipeline or its dependencies
+are all in scope.

--- a/e2e/i18n.spec.ts
+++ b/e2e/i18n.spec.ts
@@ -1,13 +1,6 @@
 import { expect, test } from '@playwright/test';
 
 test.describe('i18n', () => {
-  test('language switch navigates to the other locale', async ({ page }) => {
-    await page.goto('/es/');
-    await page.getByRole('link', { name: 'EN', exact: true }).click();
-    await expect(page).toHaveURL(/\/en\/$/);
-    await expect(page.locator('html')).toHaveAttribute('lang', 'en');
-  });
-
   test('canonical and hreflang are present per locale', async ({ page }) => {
     await page.goto('/en/');
     await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(

--- a/e2e/public.spec.ts
+++ b/e2e/public.spec.ts
@@ -8,7 +8,7 @@ test.describe('public content', () => {
     await expect(page.locator('.hero__role')).toHaveText('IA-Driven Engineer');
     await expect(page.locator('[data-nav-link]')).toHaveCount(4);
     await expect(page.locator('#path')).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'Lorem Platform' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'BastianGR' })).toBeVisible();
     await expect(page.locator('.footer__brand')).toHaveText('SebasGRios');
   });
 
@@ -21,8 +21,9 @@ test.describe('public content', () => {
   test('private-repo project hides the code button', async ({ page }) => {
     await page.goto('/es/');
     // Three projects, all have a demo link; only two expose a code link.
-    await expect(page.getByRole('link', { name: 'Ver demo' })).toHaveCount(3);
-    await expect(page.getByRole('link', { name: 'Código' })).toHaveCount(2);
+    // `exact` avoids matching the project thumbnail's "{name} — Ver página" label.
+    await expect(page.getByRole('link', { name: 'Ver página', exact: true })).toHaveCount(3);
+    await expect(page.getByRole('link', { name: 'Código', exact: true })).toHaveCount(2);
   });
 
   test('root redirects to a locale', async ({ page }) => {

--- a/e2e/public.spec.ts
+++ b/e2e/public.spec.ts
@@ -20,10 +20,11 @@ test.describe('public content', () => {
 
   test('private-repo project hides the code button', async ({ page }) => {
     await page.goto('/es/');
-    // Three projects, all have a demo link; only two expose a code link.
+    // Three projects, all have a demo link; only one exposes a code link
+    // (BastianGR is marked privateRepo, Clara Romero has no repo).
     // `exact` avoids matching the project thumbnail's "{name} — Ver página" label.
     await expect(page.getByRole('link', { name: 'Ver página', exact: true })).toHaveCount(3);
-    await expect(page.getByRole('link', { name: 'Código', exact: true })).toHaveCount(2);
+    await expect(page.getByRole('link', { name: 'Código', exact: true })).toHaveCount(1);
   });
 
   test('root redirects to a locale', async ({ page }) => {

--- a/src/content/projects/01-bastiangr.yml
+++ b/src/content/projects/01-bastiangr.yml
@@ -8,4 +8,4 @@ desc:
 tech: ["Astro", "Cloudflare"]
 demo: "https://bastiangr.es"
 repo: "https://github.com/sebasgrios/bastiangr"
-privateRepo: false
+privateRepo: true


### PR DESCRIPTION
Agrupa el endurecimiento de seguridad del repositorio, la recuperación de la CI y un ajuste de contenido.

## Cambios

- **CI (GitHub Actions):** nuevo workflow `ci.yml` que ejecuta `verify` (`pnpm check`), `test` (`pnpm test`) y `e2e` (`pnpm e2e` con Playwright) en cada PR y push a `main`/`develop`. Recupera las validaciones que se perdieron en el rewrite a v5.
- **Tests e2e:** se actualizan `public.spec.ts` e `i18n.spec.ts` para que coincidan con el contenido real de v5 (proyectos reales, etiquetas correctas) y se elimina el test del antiguo selector de idioma, ya retirado.
- **BastianGR:** se marca el proyecto como `privateRepo`, ocultando el enlace al código en la tarjeta.
- **Plantillas y políticas:** `CODEOWNERS`, plantilla de PR (en español, sin checklist), plantillas de issues (bug / feature) y `SECURITY.md` con reporte privado de vulnerabilidades.

## Notas

- Las protecciones de rama (`main` y `develop`), el reporte privado de vulnerabilidades y los ajustes de merge ya se han aplicado por API.
- Los avisos de "Node.js 20 actions are deprecated" en CI son informativos y no afectan al resultado.