### PR TITLE
✨ Header oculto en el timeline (desktop) y sin hover pegajoso en táctil — v5.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sebasgrios",
   "type": "module",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "private": true,
   "packageManager": "pnpm@11.5.3",
   "engines": {

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -96,6 +96,16 @@ const t = useTranslations(locale);
 
   // Header: shadow once scrolled, hide on scroll-down / reveal on scroll-up.
   let lastY = 0;
+  // While the pinned timeline is engaged (desktop only: vertical scroll drives
+  // its horizontal travel), keep the header hidden — scrolling back through the
+  // cards reads as "scroll up" and would otherwise reveal it. The pin
+  // (.is-pinned) only exists on desktop with motion allowed.
+  const timeline = document.querySelector<HTMLElement>('[data-timeline]');
+  const timelineEngaged = () => {
+    if (!timeline?.classList.contains('is-pinned')) return false;
+    const rect = timeline.getBoundingClientRect();
+    return rect.top <= 0 && rect.bottom >= window.innerHeight;
+  };
   // While the user navigates via an in-page anchor, the smooth scroll travels
   // downward and would otherwise hide the header. Lock it visible until the
   // scroll settles (no scroll event for a short window).
@@ -122,6 +132,11 @@ const t = useTranslations(locale);
       header?.classList.remove('is-hidden');
       lastY = y;
       releaseNavLock();
+      return;
+    }
+    if (timelineEngaged()) {
+      header?.classList.add('is-hidden');
+      lastY = y;
       return;
     }
     header?.classList.toggle('is-hidden', y > lastY && y > 200);

--- a/src/styles/projects.css
+++ b/src/styles/projects.css
@@ -43,12 +43,20 @@
 .proj__row.flip > :not(.proj__media) {
   grid-column: 2;
 }
-/* Hover: lift the frame (no image zoom). */
-.proj__media:hover,
+/* Lift the frame on keyboard focus (no image zoom). */
 .proj__media:focus-visible {
   border-color: var(--dot);
   box-shadow: 0 18px 55px -24px rgba(0, 0, 0, 0.35);
   transform: translateY(-4px);
+}
+/* Same lift on hover, but only for real pointers — on touch, :hover sticks
+   after a tap and the card stays lifted until the next tap elsewhere. */
+@media (hover: hover) {
+  .proj__media:hover {
+    border-color: var(--dot);
+    box-shadow: 0 18px 55px -24px rgba(0, 0, 0, 0.35);
+    transform: translateY(-4px);
+  }
 }
 .proj__media .media-ph {
   background: repeating-linear-gradient(135deg, var(--line-soft) 0 1px, transparent 1px 13px);

--- a/src/styles/timeline.css
+++ b/src/styles/timeline.css
@@ -119,10 +119,13 @@
     box-shadow 0.3s var(--ease),
     transform 0.3s var(--ease);
 }
-.tl-card:hover {
-  border-color: var(--dot);
-  box-shadow: 0 16px 50px -22px rgba(0, 0, 0, 0.3);
-  transform: translateY(-3px);
+/* Hover lift only for real pointers — on touch, :hover sticks after a tap. */
+@media (hover: hover) {
+  .tl-card:hover {
+    border-color: var(--dot);
+    box-shadow: 0 16px 50px -22px rgba(0, 0, 0, 0.3);
+    transform: translateY(-3px);
+  }
 }
 .tl-card__node {
   position: absolute;


### PR DESCRIPTION
## Resumen

Mejoras de UX e interacción para v5, junto con el incremento de versión a **5.1.0**.

## Cambios

- **Header en el timeline (desktop):** mientras la sección de experiencia y formación está "pineada" (el scroll vertical mueve las tarjetas en horizontal), el header permanece oculto. Antes, al deslizar hacia atrás por las tarjetas el gesto se leía como "scroll hacia arriba" y revelaba el header de forma molesta. La lógica vive en el propio `Header.astro` y solo actúa cuando el pin está activo (que únicamente existe en desktop con movimiento permitido).
- **Tarjetas en táctil:** se elimina el *lift* pegajoso al tocar una tarjeta en móvil. El efecto `:hover` (timeline y proyectos) ahora se restringe a punteros reales con `@media (hover: hover)`. Se conserva `:focus-visible` para accesibilidad de teclado.
- **Versión:** `package.json` actualizado de `5.0.0` a `5.1.0`.

## Notas

- Sin JavaScript adicional de framework; el header sigue siendo *vanilla*.
- No afecta a Lighthouse ni al gate de accesibilidad.
- Tras el *merge* conviene crear el tag `v5.1.0` sobre `main` (no se etiqueta en `develop` para evitar tags huérfanos con *squash merge*).
